### PR TITLE
ci: pass VOYAGE_API_KEY to the e2e job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
             NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
             NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
             SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+            VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}
             SKIP_SMS: 'true'
             SKIP_EMAIL: 'true'
             TEST_CLEANUP_SECRET: ${{ secrets.TEST_CLEANUP_SECRET }}


### PR DESCRIPTION
## Summary
One-line CI fix: expose the `VOYAGE_API_KEY` repo secret (now set) to the `e2e` job env. Previously the search/embedding e2e tests fell back to text search and failed because the key wasn't wired into the job.

## Testing
- Deterministic checks (lint/type-check/unit/build) unaffected — no app code changed.
- e2e should no longer fail on `Please specify VOYAGE_API_KEY`. (Pre-existing storage-fixture / worker-timeout flakiness in e2e is separate and not addressed here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)