### PR TITLE
MVP batch: password change, item actions, join fix, feedback+voice, event tags, impact dashboards

### DIFF
--- a/TWILIO_VERIFY_SETUP.md
+++ b/TWILIO_VERIFY_SETUP.md
@@ -1,0 +1,98 @@
+# Phone OTP via Twilio Verify — Setup Plan (deferred)
+
+**Status:** Phone auth (login/signup/phone-number update) is **hidden in the UI** behind
+`PHONE_AUTH_ENABLED` in `lib/feature-flags.ts` (currently `false`). All backend routes,
+validation, and DB fields remain intact. Flip the flag to `true` to re-enable the UI once
+the provider below is configured.
+
+This document is the plan to enable it later. Nothing here is wired yet.
+
+---
+
+## Decision: use Twilio **Verify** (not raw Programmable SMS)
+
+Requirements: **OTP only**, **multi-country from day 1** (US, Germany, India), **minimal config**.
+
+Twilio Verify is the right fit because it is a fully-managed OTP service:
+
+- No phone number to buy or manage; Twilio handles global routing, sender IDs, code
+  generation, expiry, rate limits, and fraud checks.
+- Far less country-regulatory setup than raw SMS (which, for India, requires full DLT
+  number + template registration).
+- Multi-channel built in (SMS now; voice / WhatsApp / email later with no rewrite).
+- ~$0.05 per successful verification (bundles the SMS cost).
+
+It **replaces** the current self-managed phone OTP path (generate → hash → store → compare).
+Email OTP is unaffected and stays as-is.
+
+### Cheaper alternatives considered
+
+- **MSG91 / Plivo** — cheaper per-message, India-friendly, but more setup and less "managed".
+- **Twilio Verify** — slightly pricier per OTP but zero number/DLT management and global by
+  default. For OTP-only across three countries with minimal ops, this wins.
+
+---
+
+## Your one-time setup (Twilio Console)
+
+1. **Create a Twilio account** at https://www.twilio.com (free trial works for testing).
+2. **Verify → Services → Create** → name it "ShareCircle" → copy the **Verify Service SID**
+   (`VAxxxxxxxx…`).
+3. **Account → API keys & tokens → Create API key** → copy the **API Key SID + Secret**
+   (used by both the app and the Twilio MCP; preferred over the raw Auth Token).
+4. Add these to `.env` (NOT committed):
+    ```
+    TWILIO_ACCOUNT_SID=ACxxxxxxxx
+    TWILIO_API_KEY=SKxxxxxxxx
+    TWILIO_API_SECRET=xxxxxxxx
+    TWILIO_VERIFY_SERVICE_SID=VAxxxxxxxx
+    ```
+    Note: with Verify you do **not** need `TWILIO_PHONE_NUMBER`.
+
+### Country notes
+
+- **US, Germany** — work immediately (trial → paid).
+- **India** — Verify still needs a lighter regulatory step than full raw-SMS DLT; check the
+  Verify onboarding prompts for India when you go live.
+- **Trial limitation:** until the account is upgraded, Verify only messages phone numbers
+  you have verified in the Twilio Console.
+
+---
+
+## Connect the Twilio MCP (so the agent can administer Twilio)
+
+The MCP must be added to Claude Code by you (the agent cannot self-connect). Either:
+
+- In Claude Code, run `/plugins` and install **`twilio-developer-kit`** (bundles MCP + skills), **or**
+- CLI:
+    ```bash
+    claude mcp add-json "twilio" '{"command":"npx","args":["-y","@twilio-alpha/mcp","ACCOUNT_SID/API_KEY:API_SECRET"]}'
+    ```
+
+Security: do not run community Twilio MCP servers alongside the official one.
+
+---
+
+## Code changes required to enable (done later, on request)
+
+1. `lib/sms.ts` → replace the `messages.create` send with Verify:
+   `client.verify.v2.services(TWILIO_VERIFY_SERVICE_SID).verifications.create({ to, channel: 'sms' })`.
+2. `app/api/auth/verify-phone-otp/route.ts` → replace the local hash comparison with
+   `...verificationChecks.create({ to, code })` and treat `status === 'approved'` as success.
+   (Phone OTPs no longer use the local `verificationToken` table; email OTP still does.)
+3. `app/api/auth/send-phone-otp/route.ts` → drop local OTP generation/storage for phone;
+   just call the Verify send. Keep the same request/response shape so the UI is untouched.
+4. Flip `PHONE_AUTH_ENABLED` to `true` in `lib/feature-flags.ts`.
+5. Live test: one verification to a Console-verified number (trial) or any number (paid).
+
+Because the request/response contracts stay the same, the existing login/signup/settings UI
+lights back up unchanged the moment the flag flips.
+
+---
+
+## References
+
+- Twilio Verify: https://www.twilio.com/docs/verify
+- Migrate Messaging → Verify: https://www.twilio.com/en-us/blog/migrate-programmable-messaging-to-verify
+- Twilio MCP: https://www.twilio.com/docs/ai/mcp
+- @twilio-alpha/mcp: https://www.npmjs.com/package/@twilio-alpha/mcp

--- a/app/api/borrow-requests/[id]/route.ts
+++ b/app/api/borrow-requests/[id]/route.ts
@@ -229,6 +229,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
 						ownerId: borrowRequest.ownerId,
 						startAt: borrowRequest.desiredFrom,
 						dueAt: borrowRequest.desiredTo,
+						event: borrowRequest.event,
 						status: BorrowTransactionStatus.ACTIVE,
 					},
 				});

--- a/app/api/borrow-requests/route.ts
+++ b/app/api/borrow-requests/route.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 const createBorrowRequestSchema = z.object({
 	itemId: z.string().min(1, 'Item ID is required'),
 	message: z.string().max(500, 'Message must be 500 characters or fewer').optional(),
+	event: z.string().max(100, 'Event must be 100 characters or fewer').optional(),
 	desiredFrom: z.string().min(1, 'Start date is required'),
 	desiredTo: z.string().min(1, 'End date is required'),
 	joinQueue: z.boolean().optional().default(false),
@@ -151,7 +152,7 @@ export async function POST(req: NextRequest) {
 				{ status: 400 },
 			);
 		}
-		const { itemId, message, desiredFrom, desiredTo, joinQueue } = parsed.data;
+		const { itemId, message, event, desiredFrom, desiredTo, joinQueue } = parsed.data;
 
 		// Fetch item and user circles in parallel (independent queries)
 		const [item, userCircleIds] = await Promise.all([
@@ -307,6 +308,7 @@ export async function POST(req: NextRequest) {
 				requesterId: userId,
 				ownerId: item.ownerId,
 				message: message?.trim() || null,
+				event: event?.trim() || null,
 				desiredFrom: new Date(desiredFrom),
 				desiredTo: new Date(desiredTo),
 				status: BorrowRequestStatus.PENDING,

--- a/app/api/circles/[id]/impact/route.ts
+++ b/app/api/circles/[id]/impact/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { MemberRole } from '@prisma/client';
+import { getCircleImpact, getCircleMemberBreakdown } from '@/lib/impact';
+
+// GET /api/circles/[id]/impact - circle impact summary (members) + per-member breakdown (admins only)
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+	try {
+		const session = await getServerSession(authOptions);
+		if (!session?.user?.id) {
+			return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+		}
+
+		const { id: circleId } = await params;
+
+		// Circle membership gate — only active members can see a circle's impact.
+		const membership = await prisma.circleMember.findFirst({
+			where: { circleId, userId: session.user.id, leftAt: null },
+		});
+		if (!membership) {
+			return NextResponse.json({ error: 'Not a member of this circle' }, { status: 403 });
+		}
+
+		const isAdmin = membership.role === MemberRole.ADMIN;
+		const [summary, members] = await Promise.all([
+			getCircleImpact(circleId),
+			isAdmin ? getCircleMemberBreakdown(circleId) : Promise.resolve([]),
+		]);
+
+		return NextResponse.json({ summary, members, isAdmin }, { status: 200 });
+	} catch (error) {
+		console.error('Get circle impact error:', error);
+		return NextResponse.json({ error: 'Failed to load circle impact' }, { status: 500 });
+	}
+}

--- a/app/api/circles/[id]/regenerate-code/route.ts
+++ b/app/api/circles/[id]/regenerate-code/route.ts
@@ -5,7 +5,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { MemberRole } from '@prisma/client';
 
-const INVITE_EXPIRY_DAYS = 7;
+const INVITE_EXPIRY_DAYS = 30;
 
 // Generate 8-character alphanumeric invite code
 function generateInviteCode(): string {

--- a/app/api/circles/route.ts
+++ b/app/api/circles/route.ts
@@ -12,7 +12,7 @@ const createCircleSchema = z.object({
 	description: z.string().trim().max(500, 'Description must be 500 characters or fewer').nullish(),
 });
 
-const INVITE_EXPIRY_DAYS = 7;
+const INVITE_EXPIRY_DAYS = 30;
 
 // Generate 8-character alphanumeric invite code
 function generateInviteCode(): string {

--- a/app/api/impact/route.ts
+++ b/app/api/impact/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { getUserImpact } from '@/lib/impact';
+
+// GET /api/impact - current user's sharing impact summary
+export async function GET() {
+	try {
+		const session = await getServerSession(authOptions);
+		if (!session?.user?.id) {
+			return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+		}
+
+		const impact = await getUserImpact(session.user.id);
+		return NextResponse.json(impact, { status: 200 });
+	} catch (error) {
+		console.error('Get impact error:', error);
+		return NextResponse.json({ error: 'Failed to load impact' }, { status: 500 });
+	}
+}

--- a/app/api/items/[id]/route.ts
+++ b/app/api/items/[id]/route.ts
@@ -72,6 +72,8 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
 					orderBy: { createdAt: 'desc' },
 					take: 1,
 					select: {
+						id: true,
+						borrowRequestId: true,
 						status: true,
 						startAt: true,
 						dueAt: true,
@@ -144,6 +146,8 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
 				// to distinguish a future "Reserved" booking from a "Currently borrowed" one.
 				activeBorrow: item.borrowTransactions[0]
 					? {
+							transactionId: item.borrowTransactions[0].id,
+							borrowRequestId: item.borrowTransactions[0].borrowRequestId,
 							borrowerId: item.borrowTransactions[0].borrower.id,
 							borrowerName: item.borrowTransactions[0].borrower.name,
 							borrowerImage: item.borrowTransactions[0].borrower.image,

--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { BorrowTransactionStatus } from '@prisma/client';
 import { getSignedUrl } from '@/lib/supabase';
+import { getTransactionImpacts } from '@/lib/impact';
 
 // GET /api/transactions - Get user's borrow transactions (as borrower or owner)
 export async function GET(req: NextRequest) {
@@ -72,6 +73,7 @@ export async function GET(req: NextRequest) {
 					select: {
 						id: true,
 						message: true,
+						event: true,
 						desiredFrom: true,
 						desiredTo: true,
 					},
@@ -81,6 +83,9 @@ export async function GET(req: NextRequest) {
 				createdAt: 'desc',
 			},
 		});
+
+		// Per-transaction impact from the v_cin_transaction_impact view (one batched query).
+		const impactMap = await getTransactionImpacts(transactions.map(t => t.id));
 
 		// Add signed URLs
 		const transactionsWithUrls = await Promise.all(
@@ -97,6 +102,7 @@ export async function GET(req: NextRequest) {
 						...transaction.item,
 						imageUrl,
 					},
+					impact: impactMap.get(transaction.id) ?? null,
 				};
 			}),
 		);

--- a/app/api/transcribe/route.ts
+++ b/app/api/transcribe/route.ts
@@ -1,0 +1,65 @@
+import { generateText } from 'ai';
+import { google } from '@ai-sdk/google';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { checkRateLimit, getClientIdentifier, rateLimitResponse, RATE_LIMITS } from '@/lib/rate-limit';
+
+// Vision/audio model calls can exceed the default serverless timeout.
+export const maxDuration = 60;
+
+const MAX_AUDIO_BYTES = 10 * 1024 * 1024; // 10MB — plenty for short voice notes
+const ALLOWED_TYPES = ['audio/webm', 'audio/ogg', 'audio/mp4', 'audio/mpeg', 'audio/wav', 'audio/x-m4a'];
+
+/**
+ * Transcribe a short audio recording to text via Gemini.
+ * Accepts multipart/form-data with an `audio` file field. Returns { text }.
+ */
+export async function POST(request: Request) {
+	try {
+		const session = await getServerSession(authOptions);
+		if (!session?.user?.id) {
+			return Response.json({ error: 'Unauthorized' }, { status: 401 });
+		}
+
+		const identifier = getClientIdentifier(request, session.user.id);
+		const rateLimitResult = checkRateLimit(identifier, 'transcribe', RATE_LIMITS.ai);
+		if (!rateLimitResult.success) {
+			return rateLimitResponse(rateLimitResult);
+		}
+
+		const form = await request.formData();
+		const audio = form.get('audio');
+		if (!(audio instanceof Blob) || audio.size === 0) {
+			return Response.json({ error: 'No audio provided' }, { status: 400 });
+		}
+		if (audio.size > MAX_AUDIO_BYTES) {
+			return Response.json({ error: 'Audio is too long. Keep it under a minute.' }, { status: 400 });
+		}
+
+		// Gemini keys off the media type; fall back to webm (what MediaRecorder emits by default).
+		const mediaType = ALLOWED_TYPES.includes(audio.type) ? audio.type : 'audio/webm';
+		const bytes = new Uint8Array(await audio.arrayBuffer());
+
+		const { text } = await generateText({
+			model: google('gemini-2.5-flash'),
+			maxRetries: 2,
+			messages: [
+				{
+					role: 'user',
+					content: [
+						{ type: 'file', data: bytes, mediaType },
+						{
+							type: 'text',
+							text: 'Transcribe this audio verbatim into plain text. Return ONLY the transcript, with no preamble, quotes, or commentary. If there is no discernible speech, return an empty string.',
+						},
+					],
+				},
+			],
+		});
+
+		return Response.json({ text: text.trim() }, { status: 200 });
+	} catch (error) {
+		console.error('Transcribe error:', error);
+		return Response.json({ error: 'Failed to transcribe audio. Please try again.' }, { status: 500 });
+	}
+}

--- a/app/api/user/change-password/route.ts
+++ b/app/api/user/change-password/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import bcrypt from 'bcryptjs';
+import { prisma } from '@/lib/prisma';
+import { authOptions } from '@/lib/auth';
+import { checkRateLimit, getClientIdentifier, rateLimitResponse } from '@/lib/rate-limit';
+import { validatePassword, getPasswordRequirementsText } from '@/lib/password-validation';
+
+/**
+ * Authenticated password change: verify the current password, then set a new one.
+ * This is intentionally independent of the email-OTP / emailVerified pipeline so a
+ * logged-in user can change their password without an email round-trip. The email-OTP
+ * flow remains available as the "forgot password" fallback.
+ */
+export async function POST(req: NextRequest) {
+	try {
+		const session = await getServerSession(authOptions);
+		if (!session?.user?.id) {
+			return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+		}
+
+		const identifier = getClientIdentifier(req);
+		const rateLimitResult = checkRateLimit(identifier, 'auth-change-password', {
+			maxRequests: 10,
+			windowSeconds: 3600,
+		});
+		if (!rateLimitResult.success) {
+			return rateLimitResponse(rateLimitResult);
+		}
+
+		const { currentPassword, newPassword } = (await req.json()) as {
+			currentPassword?: string;
+			newPassword?: string;
+		};
+
+		if (!currentPassword || !newPassword) {
+			return NextResponse.json({ error: 'Current and new password are required' }, { status: 400 });
+		}
+
+		const user = await prisma.user.findUnique({ where: { id: session.user.id } });
+		if (!user) {
+			return NextResponse.json({ error: 'User not found' }, { status: 404 });
+		}
+
+		// Social-only accounts (Google) have no password to compare against.
+		if (!user.hashed_password) {
+			return NextResponse.json(
+				{ error: 'Your account uses social login. Set a password via "Forgot password" first.' },
+				{ status: 400 },
+			);
+		}
+
+		const currentMatches = await bcrypt.compare(currentPassword, user.hashed_password);
+		if (!currentMatches) {
+			return NextResponse.json({ error: 'Current password is incorrect' }, { status: 400 });
+		}
+
+		const passwordValidation = validatePassword(newPassword);
+		if (!passwordValidation.isValid) {
+			return NextResponse.json(
+				{
+					error: passwordValidation.errors[0],
+					details: passwordValidation.errors,
+					requirements: getPasswordRequirementsText(),
+				},
+				{ status: 400 },
+			);
+		}
+
+		// Reject a no-op change so users don't think they rotated a compromised password.
+		const sameAsOld = await bcrypt.compare(newPassword, user.hashed_password);
+		if (sameAsOld) {
+			return NextResponse.json(
+				{ error: 'New password must be different from your current password' },
+				{ status: 400 },
+			);
+		}
+
+		const hashedPassword = await bcrypt.hash(newPassword, 12);
+		await prisma.user.update({
+			where: { id: user.id },
+			data: { hashed_password: hashedPassword },
+		});
+
+		return NextResponse.json({ message: 'Password changed successfully.' }, { status: 200 });
+	} catch (error) {
+		console.error('Change password error:', error);
+		return NextResponse.json({ error: 'An error occurred. Please try again.' }, { status: 500 });
+	}
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -22,6 +22,7 @@ import {
 	isSupportedPhoneCountry,
 	validatePhoneByCountry,
 } from '@/lib/phone';
+import { PHONE_AUTH_ENABLED } from '@/lib/feature-flags';
 
 type LoginMode = 'login' | 'forgot' | 'reset';
 
@@ -683,21 +684,23 @@ function LoginContent() {
 					</form>
 				) : (
 					<div className="space-y-4">
-						<Tabs
-							value={loginMethod}
-							onValueChange={value => {
-								setLoginMethod(value as 'email' | 'phone');
-								setError('');
-								setSuccessMessage('');
-								setOtpCode(EMPTY_OTP);
-							}}
-							className="w-full"
-						>
-							<TabsList className="grid w-full grid-cols-2 mb-4">
-								<TabsTrigger value="email">Email OTP</TabsTrigger>
-								<TabsTrigger value="phone">Phone OTP</TabsTrigger>
-							</TabsList>
-						</Tabs>
+						{PHONE_AUTH_ENABLED && (
+							<Tabs
+								value={loginMethod}
+								onValueChange={value => {
+									setLoginMethod(value as 'email' | 'phone');
+									setError('');
+									setSuccessMessage('');
+									setOtpCode(EMPTY_OTP);
+								}}
+								className="w-full"
+							>
+								<TabsList className="grid w-full grid-cols-2 mb-4">
+									<TabsTrigger value="email">Email OTP</TabsTrigger>
+									<TabsTrigger value="phone">Phone OTP</TabsTrigger>
+								</TabsList>
+							</Tabs>
+						)}
 
 						{loginMethod === 'email' ? (
 							<div>

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -26,6 +26,7 @@ import {
 	isSupportedPhoneCountry,
 	validatePhoneByCountry,
 } from '@/lib/phone';
+import { PHONE_AUTH_ENABLED } from '@/lib/feature-flags';
 
 type SignupMode = 'signup' | 'verify';
 
@@ -550,10 +551,12 @@ function SignupContent() {
 					className="w-full"
 					onValueChange={v => setSignupMethod(v as 'email' | 'phone')}
 				>
-					<TabsList className="grid w-full grid-cols-2 mb-6">
-						<TabsTrigger value="email">Email</TabsTrigger>
-						<TabsTrigger value="phone">Phone</TabsTrigger>
-					</TabsList>
+					{PHONE_AUTH_ENABLED && (
+						<TabsList className="grid w-full grid-cols-2 mb-6">
+							<TabsTrigger value="email">Email</TabsTrigger>
+							<TabsTrigger value="phone">Phone</TabsTrigger>
+						</TabsList>
+					)}
 
 					<form onSubmit={handleSignup} className="space-y-4">
 						<TabsContent value="email" className="space-y-4 mt-0">

--- a/components/app/mobile-header.tsx
+++ b/components/app/mobile-header.tsx
@@ -56,57 +56,62 @@ export function MobileHeader() {
 					<span className="text-sm font-semibold text-foreground">ShareCircle</span>
 				</Link>
 
-				<DropdownMenu>
-					<DropdownMenuTrigger asChild>
-						<button
-							type="button"
-							className="flex h-9 w-9 items-center justify-center rounded-full outline-none focus-visible:ring-2 focus-visible:ring-ring"
-							aria-label="Account menu"
-						>
-							<Avatar className="h-8 w-8">
-								<AvatarImage src={userImage || ''} />
-								<AvatarFallback className="bg-primary text-primary-foreground text-xs font-semibold">
-									{getInitials(displayName)}
-								</AvatarFallback>
-							</Avatar>
-						</button>
-					</DropdownMenuTrigger>
-					<DropdownMenuContent align="end" className="w-48">
-						<DropdownMenuItem asChild>
-							<Link href="/listings" className="flex items-center gap-2">
-								<List className="h-4 w-4" />
-								My Listings
-							</Link>
-						</DropdownMenuItem>
-						<DropdownMenuItem asChild>
-							<Link href="/activity" className="flex items-center gap-2">
-								<History className="h-4 w-4" />
-								My Activity
-							</Link>
-						</DropdownMenuItem>
-						<DropdownMenuItem asChild>
-							<Link href="/settings" className="flex items-center gap-2">
-								<Settings className="h-4 w-4" />
-								Settings
-							</Link>
-						</DropdownMenuItem>
-						<DropdownMenuItem
-							onClick={() => setShowFeedbackModal(true)}
-							className="flex items-center gap-2"
-						>
-							<MessageSquarePlus className="h-4 w-4" />
-							Share feedback
-						</DropdownMenuItem>
-						<DropdownMenuSeparator />
-						<DropdownMenuItem
-							onClick={handleLogout}
-							className="flex items-center gap-2 text-destructive focus:text-destructive"
-						>
-							<LogOut className="h-4 w-4" />
-							Logout
-						</DropdownMenuItem>
-					</DropdownMenuContent>
-				</DropdownMenu>
+				<div className="flex items-center gap-1">
+					{/* Feedback — surfaced to the left of the profile pic, not buried in the menu */}
+					<button
+						type="button"
+						onClick={() => setShowFeedbackModal(true)}
+						className="flex h-9 w-9 items-center justify-center rounded-full text-foreground outline-none transition-colors hover:bg-muted/80 focus-visible:ring-2 focus-visible:ring-ring"
+						aria-label="Share feedback"
+					>
+						<MessageSquarePlus className="h-5 w-5" />
+					</button>
+
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<button
+								type="button"
+								className="flex h-9 w-9 items-center justify-center rounded-full outline-none focus-visible:ring-2 focus-visible:ring-ring"
+								aria-label="Account menu"
+							>
+								<Avatar className="h-8 w-8">
+									<AvatarImage src={userImage || ''} />
+									<AvatarFallback className="bg-primary text-primary-foreground text-xs font-semibold">
+										{getInitials(displayName)}
+									</AvatarFallback>
+								</Avatar>
+							</button>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="end" className="w-48">
+							<DropdownMenuItem asChild>
+								<Link href="/listings" className="flex items-center gap-2">
+									<List className="h-4 w-4" />
+									My Listings
+								</Link>
+							</DropdownMenuItem>
+							<DropdownMenuItem asChild>
+								<Link href="/activity" className="flex items-center gap-2">
+									<History className="h-4 w-4" />
+									My Activity
+								</Link>
+							</DropdownMenuItem>
+							<DropdownMenuItem asChild>
+								<Link href="/settings" className="flex items-center gap-2">
+									<Settings className="h-4 w-4" />
+									Settings
+								</Link>
+							</DropdownMenuItem>
+							<DropdownMenuSeparator />
+							<DropdownMenuItem
+								onClick={handleLogout}
+								className="flex items-center gap-2 text-destructive focus:text-destructive"
+							>
+								<LogOut className="h-4 w-4" />
+								Logout
+							</DropdownMenuItem>
+						</DropdownMenuContent>
+					</DropdownMenu>
+				</div>
 			</header>
 
 			<FeedbackModal open={showFeedbackModal} onOpenChange={setShowFeedbackModal} />

--- a/components/app/sidebar.tsx
+++ b/components/app/sidebar.tsx
@@ -130,7 +130,7 @@ export function Sidebar() {
 						</nav>
 					</ScrollArea>
 
-					{/* Feedback */}
+					{/* Feedback — full-width, directly above the profile/logout section */}
 					<div className="px-3 pb-2">
 						<button
 							type="button"

--- a/components/cards/borrow-request-card.tsx
+++ b/components/cards/borrow-request-card.tsx
@@ -94,6 +94,7 @@ export function BorrowRequestCard({
 							</Avatar>
 							<span className="truncate">{request.requester.name || 'Unknown'}</span>
 						</div>
+						{request.event && <p className="mt-1 text-xs font-medium text-primary">For: {request.event}</p>}
 						{request.message && (
 							<p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
 								&ldquo;{request.message}&rdquo;

--- a/components/chat/MessageComposer.tsx
+++ b/components/chat/MessageComposer.tsx
@@ -2,6 +2,7 @@
 import { Camera, ImagePlus, Send, Smile, X } from 'lucide-react';
 import { type ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
+import { AudioInput } from '@/components/ui/audio-input';
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -311,6 +312,12 @@ export function MessageComposer({
 						}
 					}}
 					disabled={disabled}
+				/>
+				<AudioInput
+					aria-label="Record a voice message"
+					disabled={disabled}
+					className="h-9 w-9 rounded-xl"
+					onTranscript={text => onChange(value ? `${value} ${text}` : text)}
 				/>
 				<Button
 					size="icon"

--- a/components/impact/circle-impact-panel.tsx
+++ b/components/impact/circle-impact-panel.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { Leaf, DollarSign, HandshakeIcon, Users, Crown } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { useGetCircleImpactQuery } from '@/lib/redux/api/impactApi';
+
+function Metric({ icon, label, value }: { icon: React.ReactNode; label: string; value: string }) {
+	return (
+		<div className="flex flex-col gap-1 rounded-lg border border-border/60 bg-muted/20 px-3 py-3">
+			<div className="flex items-center gap-1.5 text-muted-foreground">
+				{icon}
+				<span className="text-xs">{label}</span>
+			</div>
+			<span className="text-lg font-semibold text-foreground sm:text-xl">{value}</span>
+		</div>
+	);
+}
+
+function initials(name: string | null) {
+	if (!name) return 'U';
+	return name
+		.split(' ')
+		.map(n => n[0])
+		.join('')
+		.toUpperCase()
+		.slice(0, 2);
+}
+
+/**
+ * Circle-level impact (every member) + per-member breakdown (admins only).
+ * Reads /api/circles/[id]/impact, backed by the v_cin_circle_* views.
+ */
+export function CircleImpactPanel({ circleId }: { circleId: string }) {
+	const { data, isLoading } = useGetCircleImpactQuery(circleId);
+	const summary = data?.summary;
+
+	return (
+		<Card className="border-border/60">
+			<CardHeader className="space-y-1 pb-3">
+				<div className="flex items-center justify-between gap-2">
+					<CardTitle className="text-base sm:text-lg">Circle impact</CardTitle>
+					<Leaf className="h-4 w-4 text-primary" />
+				</div>
+				<CardDescription className="text-xs sm:text-sm">
+					What this circle has saved by sharing instead of buying
+				</CardDescription>
+			</CardHeader>
+			<CardContent className="space-y-4">
+				{isLoading ? (
+					<div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+						{Array.from({ length: 4 }).map((_, i) => (
+							<div key={i} className="h-[72px] animate-pulse rounded-lg bg-muted/40" />
+						))}
+					</div>
+				) : !summary ? (
+					<p className="text-sm text-muted-foreground">No impact recorded for this circle yet.</p>
+				) : (
+					<div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+						<Metric
+							icon={<DollarSign className="h-3.5 w-3.5" />}
+							label="Money saved"
+							value={`$${Math.round(summary.borrowerSavingsUsd).toLocaleString()}`}
+						/>
+						<Metric
+							icon={<Leaf className="h-3.5 w-3.5" />}
+							label="CO₂ avoided"
+							value={`${(Math.round(summary.ghgSavedKg * 10) / 10).toLocaleString()} kg`}
+						/>
+						<Metric
+							icon={<HandshakeIcon className="h-3.5 w-3.5" />}
+							label="Total borrows"
+							value={summary.totalBorrows.toLocaleString()}
+						/>
+						<Metric
+							icon={<Users className="h-3.5 w-3.5" />}
+							label="Members sharing"
+							value={`${summary.uniqueLenders}/${summary.totalMembers}`}
+						/>
+					</div>
+				)}
+
+				{/* Admin-only per-member breakdown */}
+				{data?.isAdmin && data.members.length > 0 && (
+					<div className="space-y-2 pt-1">
+						<div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+							<Crown className="h-3.5 w-3.5 text-amber-500" />
+							Member breakdown (admins only)
+						</div>
+						<div className="overflow-x-auto">
+							<table className="w-full text-sm">
+								<thead>
+									<tr className="border-b border-border/60 text-left text-xs text-muted-foreground">
+										<th className="py-2 pr-2 font-medium">Member</th>
+										<th className="px-2 py-2 text-right font-medium">Lends</th>
+										<th className="px-2 py-2 text-right font-medium">Borrows</th>
+										<th className="px-2 py-2 text-right font-medium">CO₂ (kg)</th>
+										<th className="py-2 pl-2 text-right font-medium">Saved ($)</th>
+									</tr>
+								</thead>
+								<tbody>
+									{data.members.map(m => (
+										<tr key={m.userId} className="border-b border-border/40 last:border-0">
+											<td className="py-2 pr-2">
+												<div className="flex items-center gap-2">
+													<Avatar className="h-6 w-6">
+														<AvatarFallback className="text-[10px]">
+															{initials(m.userName)}
+														</AvatarFallback>
+													</Avatar>
+													<span className="truncate">{m.userName || 'Member'}</span>
+													{m.memberRole === 'ADMIN' && (
+														<Crown className="h-3 w-3 shrink-0 text-amber-500" />
+													)}
+												</div>
+											</td>
+											<td className="px-2 py-2 text-right tabular-nums">{m.lendsInCircle}</td>
+											<td className="px-2 py-2 text-right tabular-nums">{m.borrowsInCircle}</td>
+											<td className="px-2 py-2 text-right tabular-nums">
+												{Math.round(m.ghgSavedKg * 10) / 10}
+											</td>
+											<td className="py-2 pl-2 text-right tabular-nums">
+												{Math.round(m.savingsUsd).toLocaleString()}
+											</td>
+										</tr>
+									))}
+								</tbody>
+							</table>
+						</div>
+					</div>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/components/impact/impact-panel.tsx
+++ b/components/impact/impact-panel.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { Leaf, DollarSign, HandshakeIcon, Package } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useGetUserImpactQuery } from '@/lib/redux/api/impactApi';
+
+function Metric({ icon, label, value }: { icon: React.ReactNode; label: string; value: string }) {
+	return (
+		<div className="flex flex-col gap-1 rounded-lg border border-border/60 bg-muted/20 px-3 py-3">
+			<div className="flex items-center gap-1.5 text-muted-foreground">
+				{icon}
+				<span className="text-xs">{label}</span>
+			</div>
+			<span className="text-xl font-semibold text-foreground sm:text-2xl">{value}</span>
+		</div>
+	);
+}
+
+/**
+ * User-level sharing impact summary. Renders money saved, CO2 avoided, and borrow/share
+ * counts from /api/impact. Circle/transaction/lead-level views are tracked as follow-ups.
+ */
+export function ImpactPanel() {
+	const { data, isLoading } = useGetUserImpactQuery();
+
+	return (
+		<Card className="border-border/60">
+			<CardHeader className="space-y-1 pb-3">
+				<div className="flex items-center justify-between gap-2">
+					<CardTitle className="text-base sm:text-lg">Your impact</CardTitle>
+					<Leaf className="h-4 w-4 text-primary" />
+				</div>
+				<CardDescription className="text-xs sm:text-sm">
+					What sharing instead of buying has added up to
+				</CardDescription>
+			</CardHeader>
+			<CardContent>
+				{isLoading || !data ? (
+					<div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+						{Array.from({ length: 4 }).map((_, i) => (
+							<div key={i} className="h-[76px] animate-pulse rounded-lg bg-muted/40" />
+						))}
+					</div>
+				) : (
+					<div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+						<Metric
+							icon={<DollarSign className="h-3.5 w-3.5" />}
+							label="Money saved"
+							value={`$${data.moneySavedUsd.toLocaleString()}`}
+						/>
+						<Metric
+							icon={<Leaf className="h-3.5 w-3.5" />}
+							label="CO₂ avoided"
+							value={`${data.co2AvoidedKg.toLocaleString()} kg`}
+						/>
+						<Metric
+							icon={<HandshakeIcon className="h-3.5 w-3.5" />}
+							label="Times borrowed"
+							value={data.timesBorrowed.toLocaleString()}
+						/>
+						<Metric
+							icon={<Package className="h-3.5 w-3.5" />}
+							label="Items shared"
+							value={data.itemsShared.toLocaleString()}
+						/>
+					</div>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/components/modals/feedback-modal.tsx
+++ b/components/modals/feedback-modal.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
+import { AudioInput } from '@/components/ui/audio-input';
 import { cn } from '@/lib/utils';
 
 const APP_VERSION = '1.0';
@@ -217,16 +218,24 @@ export function FeedbackModal({ open, onOpenChange }: FeedbackModalProps) {
 
 							{/* Message */}
 							<div className="space-y-2">
-								<p className="text-sm font-medium">
-									Share the details{' '}
-									{isMessageRequired ? (
-										<span className="font-normal text-destructive">
-											(required for low ratings &amp; bug reports)
-										</span>
-									) : (
-										<span className="font-normal text-muted-foreground">(optional)</span>
-									)}
-								</p>
+								<div className="flex items-center justify-between gap-2">
+									<p className="text-sm font-medium">
+										Share the details{' '}
+										{isMessageRequired ? (
+											<span className="font-normal text-destructive">
+												(required for low ratings &amp; bug reports)
+											</span>
+										) : (
+											<span className="font-normal text-muted-foreground">(optional)</span>
+										)}
+									</p>
+									<AudioInput
+										aria-label="Record feedback with your voice"
+										onTranscript={text =>
+											setMessage(prev => (prev ? `${prev} ${text}` : text).slice(0, 2000))
+										}
+									/>
+								</div>
 								<Textarea
 									placeholder="The more specific you are, the more we can act on it."
 									value={message}

--- a/components/pages/circle-details-page.tsx
+++ b/components/pages/circle-details-page.tsx
@@ -69,6 +69,7 @@ import { PageShell } from '@/components/ui/page';
 import { CircleDetailSkeleton, ItemGridSkeleton } from '@/components/ui/skeletons';
 import { PageTabs, PageTabsContent, PageTabsList, PageTabsTrigger } from '@/components/ui/app-tabs';
 import { InfiniteScrollSentinel } from '@/components/ui/infinite-scroll-sentinel';
+import { CircleImpactPanel } from '@/components/impact/circle-impact-panel';
 import { useProgressivePagination } from '@/hooks/useProgressivePagination';
 import { type ItemRequestFilterValue } from '@/components/app/item-request-filter';
 import { CircleRequestsTab } from './circle-details/CircleRequestsTab';
@@ -733,6 +734,9 @@ export function CircleDetailsPage({ circleId }: CircleDetailsPageProps) {
 					</div>
 				)}
 			</div>
+
+			{/* Circle impact */}
+			<CircleImpactPanel circleId={circleId} />
 
 			{/* Items & Requests Section */}
 			<div className="space-y-4">

--- a/components/pages/dashboard-home.tsx
+++ b/components/pages/dashboard-home.tsx
@@ -15,6 +15,7 @@ import { DashboardItemSkeleton } from '@/components/ui/skeletons';
 import { useGetRecentThreadsQuery } from '@/lib/redux/api/messagesApi';
 import { useGetHomeSummaryQuery } from '@/lib/redux/api/homeApi';
 import { NoCircleState } from '@/components/ui/no-circle-state';
+import { ImpactPanel } from '@/components/impact/impact-panel';
 
 export function DashboardHome() {
 	const router = useRouter();
@@ -159,6 +160,8 @@ export function DashboardHome() {
 						</Button>
 					</div>
 				</form>
+
+				<ImpactPanel />
 
 				<div className="grid gap-3 sm:gap-4 lg:grid-cols-3">
 					<Card className="flex flex-col border-border/60">

--- a/components/pages/item-detail-page.tsx
+++ b/components/pages/item-detail-page.tsx
@@ -35,6 +35,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { ItemCard } from '@/components/cards/item-card';
 import { EditItemModal } from '@/components/modals/edit-item-modal';
 import { Textarea } from '@/components/ui/textarea';
+import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
 	Dialog,
@@ -55,6 +56,10 @@ import {
 	useGetQueueEntriesQuery,
 	useGetTransactionsQuery,
 	useExtendBorrowMutation,
+	useConfirmHandoffMutation,
+	useConfirmReceiptMutation,
+	useMarkAsReturnedMutation,
+	useConfirmReturnMutation,
 } from '@/lib/redux/api/borrowApi';
 import { PageShell } from '@/components/ui/page';
 import { isBorrowOverdue } from '@/lib/borrow-ui';
@@ -82,6 +87,7 @@ export function ItemDetailPage({ itemId }: ItemDetailPageProps) {
 	const [isArchiving, setIsArchiving] = useState(false);
 	const [newDueDate, setNewDueDate] = useState<Date | undefined>(undefined);
 	const [borrowMessage, setBorrowMessage] = useState('');
+	const [borrowEvent, setBorrowEvent] = useState('');
 	const [desiredFrom, setDesiredFrom] = useState<Date | undefined>(undefined);
 	const [desiredTo, setDesiredTo] = useState<Date | undefined>(undefined);
 
@@ -106,6 +112,34 @@ export function ItemDetailPage({ itemId }: ItemDetailPageProps) {
 	// Borrow/extend mutations
 	const [createBorrowRequest, { isLoading: isCreatingRequest }] = useCreateBorrowRequestMutation();
 	const [extendBorrow, { isLoading: isExtending }] = useExtendBorrowMutation();
+
+	// Borrow lifecycle mutations — surfaced inline so actions live where the item is viewed,
+	// not only on the Activity screen.
+	const [confirmHandoff] = useConfirmHandoffMutation();
+	const [confirmReceipt] = useConfirmReceiptMutation();
+	const [markAsReturned] = useMarkAsReturnedMutation();
+	const [confirmReturn] = useConfirmReturnMutation();
+	const [processingAction, setProcessingAction] = useState(false);
+
+	const runLifecycleAction = async (
+		action: () => Promise<unknown>,
+		success: { title: string; description?: string },
+		fallbackError: string,
+	) => {
+		setProcessingAction(true);
+		try {
+			await action();
+			toast({ title: success.title, description: success.description });
+		} catch (error) {
+			const msg =
+				error && typeof error === 'object' && 'data' in error
+					? (error.data as { error?: string })?.error || fallbackError
+					: fallbackError;
+			toast({ title: msg, variant: 'destructive' });
+		} finally {
+			setProcessingAction(false);
+		}
+	};
 
 	// Check if user already has a pending request
 	const hasPendingRequest = existingRequests.some(r => r.status === 'PENDING');
@@ -221,6 +255,7 @@ export function ItemDetailPage({ itemId }: ItemDetailPageProps) {
 			const result = await createBorrowRequest({
 				itemId,
 				message: borrowMessage.trim() || undefined,
+				event: borrowEvent.trim() || undefined,
 				desiredFrom: format(desiredFrom, 'yyyy-MM-dd'),
 				desiredTo: format(desiredTo, 'yyyy-MM-dd'),
 				joinQueue,
@@ -229,6 +264,7 @@ export function ItemDetailPage({ itemId }: ItemDetailPageProps) {
 			// Close modal and reset state immediately on success
 			setShowBorrowModal(false);
 			setBorrowMessage('');
+			setBorrowEvent('');
 			setDesiredFrom(undefined);
 			setDesiredTo(undefined);
 
@@ -670,6 +706,41 @@ export function ItemDetailPage({ itemId }: ItemDetailPageProps) {
 									<Trash2 className="h-4 w-4" />
 									Delete
 								</Button>
+								{activeBorrow?.borrowRequestId && activeBorrow.status === 'ACTIVE' && (
+									<Button
+										className="gap-2"
+										disabled={processingAction}
+										onClick={() =>
+											runLifecycleAction(
+												() => confirmHandoff(activeBorrow.borrowRequestId).unwrap(),
+												{
+													title: 'Handoff confirmed!',
+													description: 'Borrower has been notified.',
+												},
+												'Failed to confirm handoff',
+											)
+										}
+									>
+										{processingAction ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+										Confirm Item Handed Off
+									</Button>
+								)}
+								{activeBorrow?.borrowRequestId && activeBorrow.status === 'RETURN_PENDING' && (
+									<Button
+										className="gap-2"
+										disabled={processingAction}
+										onClick={() =>
+											runLifecycleAction(
+												() => confirmReturn(activeBorrow.borrowRequestId).unwrap(),
+												{ title: 'Return confirmed!', description: 'Transaction completed.' },
+												'Failed to confirm return',
+											)
+										}
+									>
+										{processingAction ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+										Confirm Return
+									</Button>
+								)}
 							</>
 						) : (
 							<Button
@@ -694,6 +765,38 @@ export function ItemDetailPage({ itemId }: ItemDetailPageProps) {
 								disabled={hasPendingRequest || isInQueue}
 							>
 								{itemWithAvailability?.isAvailable !== false ? 'Request to Borrow' : 'Join Queue'}
+							</Button>
+						)}
+						{isCurrentBorrower && activeTransaction?.status === 'LENDER_CONFIRMED' && (
+							<Button
+								className="gap-2"
+								disabled={processingAction}
+								onClick={() =>
+									runLifecycleAction(
+										() => confirmReceipt(activeTransaction.borrowRequestId).unwrap(),
+										{ title: 'Receipt confirmed!', description: 'Lender has been notified.' },
+										'Failed to confirm receipt',
+									)
+								}
+							>
+								{processingAction ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+								Confirm Item Received
+							</Button>
+						)}
+						{isCurrentBorrower && activeTransaction?.status === 'BORROWER_CONFIRMED' && (
+							<Button
+								className="gap-2"
+								disabled={processingAction}
+								onClick={() =>
+									runLifecycleAction(
+										() => markAsReturned({ id: activeTransaction.borrowRequestId }).unwrap(),
+										{ title: 'Marked as returned', description: 'Waiting for owner confirmation.' },
+										'Failed to mark as returned',
+									)
+								}
+							>
+								{processingAction ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+								Mark as Returned
 							</Button>
 						)}
 						{isCurrentBorrower && (
@@ -786,6 +889,16 @@ export function ItemDetailPage({ itemId }: ItemDetailPageProps) {
 									placeholder="Pick a date"
 								/>
 							</div>
+						</div>
+						<div className="space-y-2">
+							<Label htmlFor="event">What&apos;s it for? (optional)</Label>
+							<Input
+								id="event"
+								placeholder="e.g. Wedding, Camping trip, Birthday party"
+								value={borrowEvent}
+								onChange={e => setBorrowEvent(e.target.value)}
+								maxLength={100}
+							/>
 						</div>
 						<div className="space-y-2">
 							<Label htmlFor="message">Message (optional)</Label>

--- a/components/pages/my-activity-page.tsx
+++ b/components/pages/my-activity-page.tsx
@@ -12,6 +12,7 @@ import {
 	HandshakeIcon,
 	History,
 	CheckCircle2,
+	Leaf,
 } from 'lucide-react';
 import { RequestCardListSkeleton } from '@/components/ui/skeletons';
 import { Button } from '@/components/ui/button';
@@ -126,6 +127,24 @@ function ActiveTransactionCard({
 							Due: {new Date(transaction.dueAt).toLocaleDateString()}
 							{overdue && ' — overdue'}
 						</p>
+						{transaction.borrowRequest?.event && (
+							<p className="text-xs mt-1 font-medium text-primary">
+								For: {transaction.borrowRequest.event}
+							</p>
+						)}
+						{transaction.impact && transaction.impact.ghgSavedKg > 0 && (
+							<div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+								<span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-[11px] font-medium text-green-700 dark:bg-green-950 dark:text-green-300">
+									<Leaf className="h-3 w-3" />
+									{Math.round(transaction.impact.ghgSavedKg * 10) / 10} kg CO₂ saved
+								</span>
+								{transaction.impact.borrowerSavingsUsd > 0 && (
+									<span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+										${Math.round(transaction.impact.borrowerSavingsUsd).toLocaleString()} saved
+									</span>
+								)}
+							</div>
+						)}
 
 						{/* Owner actions */}
 						{role === 'owner' && isActive && onConfirmHandoff && (

--- a/components/pages/settings-page.tsx
+++ b/components/pages/settings-page.tsx
@@ -35,6 +35,7 @@ import {
 	isSupportedPhoneCountry,
 	validatePhoneByCountry,
 } from '@/lib/phone';
+import { PHONE_AUTH_ENABLED } from '@/lib/feature-flags';
 import {
 	selectUserImage,
 	selectUserName,
@@ -86,13 +87,16 @@ export function SettingsPage() {
 	const [contactCooldown, setContactCooldown] = useState(0);
 	const [contactOtp, setContactOtp] = useState(['', '', '', '', '', '']);
 	const contactOtpRefs = useRef<(HTMLInputElement | null)[]>([]);
-	const [passwordStep, setPasswordStep] = useState<'idle' | 'request' | 'verify' | 'reset' | 'success'>('idle');
+	const [passwordStep, setPasswordStep] = useState<'idle' | 'change' | 'request' | 'verify' | 'reset' | 'success'>(
+		'idle',
+	);
 	const [passwordError, setPasswordError] = useState('');
 	const [passwordSuccess, setPasswordSuccess] = useState('');
 	const [passwordIsLoading, setPasswordIsLoading] = useState(false);
 	const [resendCooldown, setResendCooldown] = useState(0);
 	const [otpCode, setOtpCode] = useState(['', '', '', '', '', '']);
 	const [resetToken, setResetToken] = useState('');
+	const [currentPassword, setCurrentPassword] = useState('');
 	const [newPassword, setNewPassword] = useState('');
 	const [confirmNewPassword, setConfirmNewPassword] = useState('');
 	const otpInputRefs = useRef<(HTMLInputElement | null)[]>([]);
@@ -284,6 +288,49 @@ export function SettingsPage() {
 
 	const accountEmail = userEmail || email;
 
+	const handleChangePassword = async (e: React.FormEvent) => {
+		e.preventDefault();
+		setPasswordError('');
+		setPasswordSuccess('');
+
+		if (!currentPassword || !newPassword || !confirmNewPassword) {
+			setPasswordError('Please fill in all fields.');
+			return;
+		}
+		if (newPassword.length < 8) {
+			setPasswordError('Password must be at least 8 characters.');
+			return;
+		}
+		if (newPassword !== confirmNewPassword) {
+			setPasswordError('Passwords do not match.');
+			return;
+		}
+
+		setPasswordIsLoading(true);
+		try {
+			const response = await fetch('/api/user/change-password', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ currentPassword, newPassword }),
+			});
+			const data = await response.json();
+			if (!response.ok) {
+				setPasswordError(data.error || 'Failed to change password.');
+				setPasswordIsLoading(false);
+				return;
+			}
+			setPasswordStep('success');
+			setPasswordSuccess('Password updated successfully.');
+			setCurrentPassword('');
+			setNewPassword('');
+			setConfirmNewPassword('');
+		} catch {
+			setPasswordError('Failed to change password. Please try again.');
+		} finally {
+			setPasswordIsLoading(false);
+		}
+	};
+
 	const handleRequestPasswordOtp = async () => {
 		setPasswordError('');
 		setPasswordSuccess('');
@@ -449,6 +496,62 @@ export function SettingsPage() {
 						Done
 					</Button>
 				</div>
+			);
+		}
+
+		if (passwordStep === 'change') {
+			return (
+				<form onSubmit={handleChangePassword} className="rounded-lg border p-4 space-y-4">
+					<div>
+						<Label className="text-sm">Current Password</Label>
+						<PasswordInput
+							value={currentPassword}
+							onChange={e => setCurrentPassword(e.target.value)}
+							className="mt-2"
+							disabled={passwordIsLoading}
+						/>
+					</div>
+					<div>
+						<Label className="text-sm">New Password</Label>
+						<PasswordInput
+							value={newPassword}
+							onChange={e => setNewPassword(e.target.value)}
+							className="mt-2"
+							disabled={passwordIsLoading}
+						/>
+						<p className="text-xs text-muted-foreground mt-1">Must be at least 8 characters.</p>
+					</div>
+					<div>
+						<Label className="text-sm">Confirm New Password</Label>
+						<PasswordInput
+							value={confirmNewPassword}
+							onChange={e => setConfirmNewPassword(e.target.value)}
+							className="mt-2"
+							disabled={passwordIsLoading}
+						/>
+					</div>
+					<div className="flex flex-col sm:flex-row sm:items-center gap-2">
+						<Button type="submit" className="w-full sm:w-auto" disabled={passwordIsLoading}>
+							{passwordIsLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+							Update Password
+						</Button>
+						<Button
+							type="button"
+							variant="ghost"
+							onClick={() => {
+								setPasswordError('');
+								setPasswordSuccess('');
+								setCurrentPassword('');
+								setNewPassword('');
+								setConfirmNewPassword('');
+								setPasswordStep('request');
+							}}
+							disabled={passwordIsLoading}
+						>
+							Forgot current password?
+						</Button>
+					</div>
+				</form>
 			);
 		}
 
@@ -674,66 +777,72 @@ export function SettingsPage() {
 									</p>
 								</div>
 
-								<div className="space-y-2">
-									<Label htmlFor="phone">Phone Number</Label>
-									<div className="flex gap-2">
-										<Select
-											value={phoneCountry}
-											onValueChange={value => {
-												if (isSupportedPhoneCountry(value)) {
-													setPhoneCountry(value);
-												}
-											}}
-											disabled={contactIsLoading}
-										>
-											<SelectTrigger className="w-[130px]">
-												<SelectValue placeholder="Code" />
-											</SelectTrigger>
-											<SelectContent>
-												{PHONE_COUNTRIES.map(phoneCountryOption => (
-													<SelectItem
-														key={phoneCountryOption.iso2}
-														value={phoneCountryOption.iso2}
-													>
-														{phoneCountryOption.flag}{' '}
-														{getDialCodeForCountry(phoneCountryOption.iso2)}
-													</SelectItem>
-												))}
-											</SelectContent>
-										</Select>
-										<div className="relative flex-1">
-											<Smartphone className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
-											<Input
-												id="phone"
-												value={phone}
-												onChange={e => setPhone(e.target.value)}
-												placeholder="Phone number"
-												className="pl-9"
+								{PHONE_AUTH_ENABLED && (
+									<div className="space-y-2">
+										<Label htmlFor="phone">Phone Number</Label>
+										<div className="flex gap-2">
+											<Select
+												value={phoneCountry}
+												onValueChange={value => {
+													if (isSupportedPhoneCountry(value)) {
+														setPhoneCountry(value);
+													}
+												}}
 												disabled={contactIsLoading}
-											/>
+											>
+												<SelectTrigger className="w-[130px]">
+													<SelectValue placeholder="Code" />
+												</SelectTrigger>
+												<SelectContent>
+													{PHONE_COUNTRIES.map(phoneCountryOption => (
+														<SelectItem
+															key={phoneCountryOption.iso2}
+															value={phoneCountryOption.iso2}
+														>
+															{phoneCountryOption.flag}{' '}
+															{getDialCodeForCountry(phoneCountryOption.iso2)}
+														</SelectItem>
+													))}
+												</SelectContent>
+											</Select>
+											<div className="relative flex-1">
+												<Smartphone className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+												<Input
+													id="phone"
+													value={phone}
+													onChange={e => setPhone(e.target.value)}
+													placeholder="Phone number"
+													className="pl-9"
+													disabled={contactIsLoading}
+												/>
+											</div>
 										</div>
+										{contactError && <p className="text-xs text-destructive">{contactError}</p>}
+										{contactSuccess && (
+											<p className="text-xs text-green-600 dark:text-green-300">
+												{contactSuccess}
+											</p>
+										)}
 									</div>
-									{contactError && <p className="text-xs text-destructive">{contactError}</p>}
-									{contactSuccess && (
-										<p className="text-xs text-green-600 dark:text-green-300">{contactSuccess}</p>
-									)}
+								)}
+							</div>
+
+							{PHONE_AUTH_ENABLED && (
+								<div className="flex justify-end pt-4">
+									<Button onClick={handleUpdateContactInfo} disabled={contactIsLoading}>
+										{contactIsLoading ? (
+											<>
+												<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+												Sending code...
+											</>
+										) : (
+											'Update Contact Info'
+										)}
+									</Button>
 								</div>
-							</div>
+							)}
 
-							<div className="flex justify-end pt-4">
-								<Button onClick={handleUpdateContactInfo} disabled={contactIsLoading}>
-									{contactIsLoading ? (
-										<>
-											<Loader2 className="mr-2 h-4 w-4 animate-spin" />
-											Sending code...
-										</>
-									) : (
-										'Update Contact Info'
-									)}
-								</Button>
-							</div>
-
-							{contactStep === 'verify' && (
+							{PHONE_AUTH_ENABLED && contactStep === 'verify' && (
 								<div className="rounded-lg border p-4 space-y-4">
 									<div className="text-sm text-muted-foreground">
 										Enter the 6-digit code sent to {getDialCodeForCountry(phoneCountry)} {phone}.
@@ -788,14 +897,19 @@ export function SettingsPage() {
 							<div className="flex items-center justify-between p-4 border rounded-lg">
 								<div className="space-y-0.5">
 									<div className="font-medium">Password</div>
-									<div className="text-sm text-muted-foreground">Verify by OTP before updating.</div>
+									<div className="text-sm text-muted-foreground">
+										Enter your current password to set a new one.
+									</div>
 								</div>
 								<Button
 									variant="outline"
 									onClick={() => {
 										setPasswordError('');
 										setPasswordSuccess('');
-										setPasswordStep('request');
+										setCurrentPassword('');
+										setNewPassword('');
+										setConfirmNewPassword('');
+										setPasswordStep('change');
 									}}
 								>
 									Change Password

--- a/components/ui/audio-input.tsx
+++ b/components/ui/audio-input.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { Loader2, Mic, Square } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { toast } from 'sonner';
+
+interface AudioInputProps {
+	/** Called with the transcribed text once recording is processed. */
+	onTranscript: (text: string) => void;
+	disabled?: boolean;
+	className?: string;
+	/** Optional label for screen readers; defaults describe the record action. */
+	'aria-label'?: string;
+}
+
+type Phase = 'idle' | 'recording' | 'transcribing';
+
+/**
+ * A single mic button that records a short voice note, sends it to /api/transcribe,
+ * and hands the resulting text back via onTranscript. Drop it next to any text input.
+ */
+export function AudioInput({ onTranscript, disabled, className, ...rest }: AudioInputProps) {
+	const [phase, setPhase] = useState<Phase>('idle');
+	const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+	const chunksRef = useRef<Blob[]>([]);
+	const streamRef = useRef<MediaStream | null>(null);
+
+	const stopStream = () => {
+		streamRef.current?.getTracks().forEach(track => track.stop());
+		streamRef.current = null;
+	};
+
+	const transcribe = async (blob: Blob) => {
+		setPhase('transcribing');
+		try {
+			const form = new FormData();
+			form.append('audio', blob, 'recording.webm');
+			const res = await fetch('/api/transcribe', { method: 'POST', body: form });
+			const data = await res.json();
+			if (!res.ok) {
+				toast.error(data.error || 'Could not transcribe audio.');
+				return;
+			}
+			const text = (data.text || '').trim();
+			if (!text) {
+				toast.error('No speech detected. Try again.');
+				return;
+			}
+			onTranscript(text);
+		} catch {
+			toast.error('Could not transcribe audio. Please try again.');
+		} finally {
+			setPhase('idle');
+		}
+	};
+
+	const startRecording = async () => {
+		if (
+			typeof navigator === 'undefined' ||
+			!navigator.mediaDevices?.getUserMedia ||
+			typeof MediaRecorder === 'undefined'
+		) {
+			toast.error('Voice input is not supported on this device.');
+			return;
+		}
+		try {
+			const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+			streamRef.current = stream;
+			chunksRef.current = [];
+			const recorder = new MediaRecorder(stream);
+			mediaRecorderRef.current = recorder;
+			recorder.ondataavailable = e => {
+				if (e.data.size > 0) chunksRef.current.push(e.data);
+			};
+			recorder.onstop = () => {
+				stopStream();
+				const blob = new Blob(chunksRef.current, { type: recorder.mimeType || 'audio/webm' });
+				if (blob.size > 0) void transcribe(blob);
+				else setPhase('idle');
+			};
+			recorder.start();
+			setPhase('recording');
+		} catch {
+			stopStream();
+			toast.error('Microphone access was denied.');
+			setPhase('idle');
+		}
+	};
+
+	const stopRecording = () => {
+		if (mediaRecorderRef.current?.state === 'recording') mediaRecorderRef.current.stop();
+	};
+
+	const handleClick = () => {
+		if (phase === 'idle') void startRecording();
+		else if (phase === 'recording') stopRecording();
+	};
+
+	return (
+		<Button
+			type="button"
+			variant={phase === 'recording' ? 'destructive' : 'outline'}
+			size="icon"
+			disabled={disabled || phase === 'transcribing'}
+			onClick={handleClick}
+			className={cn('shrink-0', className)}
+			aria-label={
+				rest['aria-label'] ||
+				(phase === 'recording'
+					? 'Stop recording'
+					: phase === 'transcribing'
+						? 'Transcribing'
+						: 'Record voice input')
+			}
+		>
+			{phase === 'transcribing' ? (
+				<Loader2 className="h-4 w-4 animate-spin" />
+			) : phase === 'recording' ? (
+				<Square className="h-4 w-4" />
+			) : (
+				<Mic className="h-4 w-4" />
+			)}
+		</Button>
+	);
+}

--- a/lib/feature-flags.ts
+++ b/lib/feature-flags.ts
@@ -1,0 +1,11 @@
+/**
+ * Phone-based auth (phone login, phone signup, and phone-number updates in Settings)
+ * is hidden for the MVP launch until the SMS/OTP provider is configured.
+ *
+ * Flip to `true` to re-enable the entire phone UI at once — the backend routes
+ * (send-phone-otp / verify-phone-otp), validation, and DB fields all remain intact
+ * behind this flag, so nothing else needs to change.
+ *
+ * Provider setup (Twilio Verify) is documented in TWILIO_VERIFY_SETUP.md.
+ */
+export const PHONE_AUTH_ENABLED = false;

--- a/lib/impact.ts
+++ b/lib/impact.ts
@@ -1,0 +1,182 @@
+import { prisma } from '@/lib/prisma';
+import { Prisma } from '@prisma/client';
+
+/**
+ * User-level sharing impact.
+ *
+ * Source of truth is the `v_cin_user_impact_summary` Postgres view (defined in Supabase),
+ * which aggregates per-transaction impact from `v_cin_transaction_impact` using the
+ * cin_* reference tables (category emission factors, retail values, attribution rates,
+ * data-gap/confidence handling). Being a regular view, it always reflects live data —
+ * any change to transactions/items/factors is picked up on the next read, no refresh needed.
+ *
+ * We read the aggregate columns rather than recomputing anything client-side.
+ */
+
+export interface UserImpact {
+	itemsShared: number;
+	timesLent: number;
+	timesBorrowed: number;
+	moneySavedUsd: number;
+	co2AvoidedKg: number;
+}
+
+const EMPTY_IMPACT: UserImpact = {
+	itemsShared: 0,
+	timesLent: 0,
+	timesBorrowed: 0,
+	moneySavedUsd: 0,
+	co2AvoidedKg: 0,
+};
+
+export interface CircleImpact {
+	circleId: string;
+	circleName: string | null;
+	totalMembers: number;
+	totalBorrows: number;
+	uniqueBorrowers: number;
+	uniqueLenders: number;
+	ghgSavedKg: number;
+	weightDivertedKg: number;
+	borrowerSavingsUsd: number;
+	retailValueSharedUsd: number;
+	repeatBorrowerRate: number;
+}
+
+export interface CircleMemberImpact {
+	userId: string;
+	userName: string | null;
+	memberRole: string;
+	borrowsInCircle: number;
+	lendsInCircle: number;
+	ghgSavedKg: number;
+	savingsUsd: number;
+	valueSharedUsd: number;
+}
+
+export interface TransactionImpact {
+	ghgSavedKg: number;
+	weightDivertedKg: number;
+	borrowerSavingsUsd: number;
+	impactConfidence: string | null;
+	hasDataGaps: boolean;
+}
+
+/** Circle-level impact summary (visible to every member). Reads v_cin_circle_impact_summary. */
+export async function getCircleImpact(circleId: string): Promise<CircleImpact | null> {
+	try {
+		const rows = await prisma.$queryRaw<CircleImpact[]>`
+			SELECT
+				circle_id                              AS "circleId",
+				circle_name                            AS "circleName",
+				COALESCE(total_members, 0)::int        AS "totalMembers",
+				COALESCE(total_borrows, 0)::int        AS "totalBorrows",
+				COALESCE(unique_borrowers, 0)::int     AS "uniqueBorrowers",
+				COALESCE(unique_lenders, 0)::int       AS "uniqueLenders",
+				COALESCE(total_ghg_saved_kg_co2e, 0)::float8      AS "ghgSavedKg",
+				COALESCE(total_weight_diverted_kg, 0)::float8     AS "weightDivertedKg",
+				COALESCE(total_borrower_savings_usd, 0)::float8   AS "borrowerSavingsUsd",
+				COALESCE(total_retail_value_shared_usd, 0)::float8 AS "retailValueSharedUsd",
+				COALESCE(repeat_borrower_rate, 0)::float8         AS "repeatBorrowerRate"
+			FROM v_cin_circle_impact_summary
+			WHERE circle_id = ${circleId}
+			LIMIT 1
+		`;
+		return rows[0] ?? null;
+	} catch (err) {
+		console.error('Impact: v_cin_circle_impact_summary unavailable:', err);
+		return null;
+	}
+}
+
+/** Per-member breakdown within a circle (admin-only surface). Reads v_cin_circle_member_breakdown. */
+export async function getCircleMemberBreakdown(circleId: string): Promise<CircleMemberImpact[]> {
+	try {
+		return await prisma.$queryRaw<CircleMemberImpact[]>`
+			SELECT
+				user_id                                   AS "userId",
+				user_name                                 AS "userName",
+				member_role::text                         AS "memberRole",
+				COALESCE(borrows_in_circle, 0)::int       AS "borrowsInCircle",
+				COALESCE(lends_in_circle, 0)::int         AS "lendsInCircle",
+				COALESCE(ghg_saved_in_circle_kg_co2e, 0)::float8 AS "ghgSavedKg",
+				COALESCE(savings_in_circle_usd, 0)::float8       AS "savingsUsd",
+				COALESCE(value_shared_in_circle_usd, 0)::float8  AS "valueSharedUsd"
+			FROM v_cin_circle_member_breakdown
+			WHERE circle_id = ${circleId}
+			ORDER BY ghg_saved_in_circle_kg_co2e DESC NULLS LAST, lends_in_circle DESC
+		`;
+	} catch (err) {
+		console.error('Impact: v_cin_circle_member_breakdown unavailable:', err);
+		return [];
+	}
+}
+
+/** Batch per-transaction impact keyed by transaction id. Reads v_cin_transaction_impact. */
+export async function getTransactionImpacts(transactionIds: string[]): Promise<Map<string, TransactionImpact>> {
+	const map = new Map<string, TransactionImpact>();
+	if (transactionIds.length === 0) return map;
+	try {
+		const rows = await prisma.$queryRaw<(TransactionImpact & { transactionId: string })[]>`
+			SELECT
+				transaction_id                          AS "transactionId",
+				COALESCE(ghg_saved_kg_co2e, 0)::float8   AS "ghgSavedKg",
+				COALESCE(weight_diverted_kg, 0)::float8  AS "weightDivertedKg",
+				COALESCE(borrower_savings_usd, 0)::float8 AS "borrowerSavingsUsd",
+				impact_confidence                       AS "impactConfidence",
+				COALESCE(has_data_gaps, false)          AS "hasDataGaps"
+			FROM v_cin_transaction_impact
+			WHERE transaction_id IN (${Prisma.join(transactionIds)})
+		`;
+		for (const row of rows) {
+			const { transactionId, ...rest } = row;
+			map.set(transactionId, rest);
+		}
+		return map;
+	} catch (err) {
+		console.error('Impact: v_cin_transaction_impact unavailable:', err);
+		return map;
+	}
+}
+
+export async function getUserImpact(userId: string): Promise<UserImpact> {
+	try {
+		// Cast bigint/numeric columns to float8/int so they return as JS numbers (not BigInt/string).
+		const rows = await prisma.$queryRaw<
+			{
+				itemsShared: number;
+				timesLent: number;
+				timesBorrowed: number;
+				moneySavedUsd: number;
+				co2AvoidedKg: number;
+			}[]
+		>`
+			SELECT
+				COALESCE(total_items_listed, 0)::int         AS "itemsShared",
+				COALESCE(total_lends, 0)::int                AS "timesLent",
+				COALESCE(total_borrows, 0)::int              AS "timesBorrowed",
+				COALESCE(total_borrower_savings_usd, 0)::float8 AS "moneySavedUsd",
+				COALESCE(total_ghg_saved_kg_co2e, 0)::float8    AS "co2AvoidedKg"
+			FROM v_cin_user_impact_summary
+			WHERE user_id = ${userId}
+			LIMIT 1
+		`;
+
+		// A user with no activity has no row in the view — that's zero impact, not an error.
+		const row = rows[0];
+		if (!row) return EMPTY_IMPACT;
+
+		return {
+			itemsShared: row.itemsShared,
+			timesLent: row.timesLent,
+			timesBorrowed: row.timesBorrowed,
+			moneySavedUsd: Math.round(row.moneySavedUsd),
+			co2AvoidedKg: Math.round(row.co2AvoidedKg * 10) / 10,
+		};
+	} catch (err) {
+		// If the view isn't present (e.g. a local DB without the cin_* views), degrade to zeros
+		// rather than failing the dashboard.
+		console.error('Impact: v_cin_user_impact_summary unavailable:', err);
+		return EMPTY_IMPACT;
+	}
+}

--- a/lib/redux/api/borrowApi.ts
+++ b/lib/redux/api/borrowApi.ts
@@ -72,6 +72,7 @@ export interface BorrowTransaction {
 export interface BorrowRequest {
 	id: string;
 	message: string | null;
+	event: string | null;
 	desiredFrom: string;
 	desiredTo: string;
 	status: BorrowRequestStatus;
@@ -87,6 +88,7 @@ export interface BorrowRequest {
 export interface CreateBorrowRequestInput {
 	itemId: string;
 	message?: string;
+	event?: string;
 	desiredFrom: string;
 	desiredTo: string;
 	joinQueue?: boolean;
@@ -136,9 +138,17 @@ export interface FullTransaction {
 	borrowRequest: {
 		id: string;
 		message: string | null;
+		event: string | null;
 		desiredFrom: string;
 		desiredTo: string;
 	};
+	impact?: {
+		ghgSavedKg: number;
+		weightDivertedKg: number;
+		borrowerSavingsUsd: number;
+		impactConfidence: string | null;
+		hasDataGaps: boolean;
+	} | null;
 }
 
 export interface GetTransactionsFilters {

--- a/lib/redux/api/impactApi.ts
+++ b/lib/redux/api/impactApi.ts
@@ -1,0 +1,57 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+
+export interface UserImpact {
+	itemsShared: number;
+	timesLent: number;
+	timesBorrowed: number;
+	moneySavedUsd: number;
+	co2AvoidedKg: number;
+}
+
+export interface CircleImpact {
+	circleId: string;
+	circleName: string | null;
+	totalMembers: number;
+	totalBorrows: number;
+	uniqueBorrowers: number;
+	uniqueLenders: number;
+	ghgSavedKg: number;
+	weightDivertedKg: number;
+	borrowerSavingsUsd: number;
+	retailValueSharedUsd: number;
+	repeatBorrowerRate: number;
+}
+
+export interface CircleMemberImpact {
+	userId: string;
+	userName: string | null;
+	memberRole: string;
+	borrowsInCircle: number;
+	lendsInCircle: number;
+	ghgSavedKg: number;
+	savingsUsd: number;
+	valueSharedUsd: number;
+}
+
+export interface CircleImpactResponse {
+	summary: CircleImpact | null;
+	members: CircleMemberImpact[];
+	isAdmin: boolean;
+}
+
+export const impactApi = createApi({
+	reducerPath: 'impactApi',
+	baseQuery: fetchBaseQuery({ baseUrl: '/api', credentials: 'include' }),
+	keepUnusedDataFor: 120,
+	refetchOnReconnect: true,
+	endpoints: builder => ({
+		getUserImpact: builder.query<UserImpact, void>({
+			query: () => '/impact',
+		}),
+		getCircleImpact: builder.query<CircleImpactResponse, string>({
+			query: circleId => `/circles/${circleId}/impact`,
+		}),
+	}),
+});
+
+export const { useGetUserImpactQuery, useGetCircleImpactQuery } = impactApi;

--- a/lib/redux/api/itemsApi.ts
+++ b/lib/redux/api/itemsApi.ts
@@ -31,6 +31,8 @@ export interface Item {
 	isAvailable?: boolean;
 	borrowedUntil?: string | null;
 	activeBorrow?: {
+		transactionId: string;
+		borrowRequestId: string;
 		borrowerId: string;
 		borrowerName: string | null;
 		borrowerImage: string | null;

--- a/lib/redux/store.ts
+++ b/lib/redux/store.ts
@@ -9,6 +9,7 @@ import { messagesApi } from './api/messagesApi';
 import { circlesApi } from './api/circlesApi';
 import { notificationPreferencesApi } from './api/notificationPreferencesApi';
 import { homeApi } from './api/homeApi';
+import { impactApi } from './api/impactApi';
 
 export const store = configureStore({
 	reducer: {
@@ -22,6 +23,7 @@ export const store = configureStore({
 		[circlesApi.reducerPath]: circlesApi.reducer,
 		[notificationPreferencesApi.reducerPath]: notificationPreferencesApi.reducer,
 		[homeApi.reducerPath]: homeApi.reducer,
+		[impactApi.reducerPath]: impactApi.reducer,
 	},
 	middleware: getDefaultMiddleware =>
 		getDefaultMiddleware().concat(
@@ -33,6 +35,7 @@ export const store = configureStore({
 			circlesApi.middleware,
 			notificationPreferencesApi.middleware,
 			homeApi.middleware,
+			impactApi.middleware,
 		),
 });
 

--- a/prisma/migrations/20260715120000_borrow_event_and_invite_expiry/migration.sql
+++ b/prisma/migrations/20260715120000_borrow_event_and_invite_expiry/migration.sql
@@ -1,0 +1,14 @@
+-- Batch #2 additive schema changes.
+--
+-- 1) Optional "event"/occasion free-text on borrow requests and the transactions
+--    they spawn (e.g. "Wedding", "Camping trip"). Nullable, no backfill needed.
+-- 2) Extend the invite-link expiry default from 7 to 30 days so shared links stay
+--    valid long enough to actually be used. Only affects rows created after this runs.
+--
+-- Idempotent (IF NOT EXISTS) so it is safe to apply on databases where the columns
+-- were already added out-of-band.
+
+ALTER TABLE "borrow_requests" ADD COLUMN IF NOT EXISTS "event" TEXT;
+ALTER TABLE "borrow_transactions" ADD COLUMN IF NOT EXISTS "event" TEXT;
+
+ALTER TABLE "circles" ALTER COLUMN "invite_expires_at" SET DEFAULT (now() + interval '30 days');

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -198,7 +198,7 @@ model Circle {
   name        String
   description String?  @db.Text
   inviteCode  String   @unique @map("invite_code")
-  inviteExpiresAt DateTime @default(dbgenerated("now() + interval '7 days'")) @map("invite_expires_at")
+  inviteExpiresAt DateTime @default(dbgenerated("now() + interval '30 days'")) @map("invite_expires_at")
   avatarUrl   String?  @map("avatar_url")
   avatarPath  String?  @map("avatar_path")
   createdById String   @map("created_by")
@@ -438,6 +438,8 @@ model BorrowRequest {
   requesterId String              @map("requester_id")
   ownerId     String              @map("owner_id")
   message     String?             @db.Text
+  // Optional occasion the borrow is for (e.g. "Wedding", "Camping trip"). Free text.
+  event       String?             @db.Text
   desiredFrom DateTime            @map("desired_from")
   desiredTo   DateTime            @map("desired_to")
   status      BorrowRequestStatus @default(PENDING)
@@ -497,6 +499,8 @@ model BorrowTransaction {
   returnedAt      DateTime?                @map("returned_at")
   status          BorrowTransactionStatus  @default(ACTIVE)
   returnNote      String?                  @map("return_note") @db.Text
+  // Occasion carried over from the borrow request (e.g. "Wedding"). Free text.
+  event           String?                  @db.Text
   createdAt       DateTime                 @default(now()) @map("created_at")
   updatedAt       DateTime                 @updatedAt @map("updated_at")
 


### PR DESCRIPTION
Second Claude-code batch for MVP launch. All changes verified: \`tsc\` clean, ESLint 0 errors, Prettier clean, 285/285 unit tests, production build compiles all routes.

## Bugs
- **Password change**: new \`POST /api/user/change-password\` (bcrypt current→new), removes the email-OTP/verification dependency that was blocking it. OTP kept as fallback.
- **Item lifecycle actions**: Confirm Handoff/Received + Mark/Confirm Return now render on the item page (borrower + owner), not just Activity. Item API returns transaction ids in \`activeBorrow\`.
- **Join circle**: invite-link expiry extended 7 → 30 days (create + regenerate + schema default).

## Features
- **Feedback**: full-width button above desktop sidebar profile; standalone icon left of the mobile avatar (out of the dropdown).
- **Voice input**: reusable \`AudioInput\` + \`POST /api/transcribe\` (Gemini), wired into feedback + chat composer.
- **Event tagging**: optional occasion (e.g. "Wedding") on a borrow, propagated to the transaction, shown on cards/activity.
- **Impact (4 levels)**: reads live Supabase \`v_cin_*\` views (auto-updating) — user (dashboard), circle (circle page), circle-lead member breakdown (admins), per-transaction chips.

## Phone auth
Hidden behind \`PHONE_AUTH_ENABLED\` (\`lib/feature-flags.ts\`, default false) for MVP until an SMS provider is set up. Backend intact. Plan in \`TWILIO_VERIFY_SETUP.md\`.

## Migration
Additive (idempotent): \`event\` columns on borrow_requests/borrow_transactions + 30-day invite default. Already applied to the shared DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)