### PR TITLE
fix(search): restore items.search_vector so semantic search works

### DIFF
--- a/prisma/migrations/20260716120000_readd_items_search_vector/migration.sql
+++ b/prisma/migrations/20260716120000_readd_items_search_vector/migration.sql
@@ -1,0 +1,40 @@
+-- Restore items.search_vector as a GENERATED tsvector column.
+--
+-- Background: 20260412000000_drop_stale_search_vector_trigger removed the old
+-- trigger-maintained search_vector column (its trigger was firing on a column that
+-- had been dropped). Later, 20260609120000_fix_search_items_text_match reintroduced
+-- references to i.search_vector inside search_items() for hybrid text+vector ranking —
+-- but the column no longer existed, so every call to search_items() errors with
+-- "column i.search_vector does not exist" and the app silently falls back to plain
+-- text search (semantic/vector search never runs).
+--
+-- Fix: recreate search_vector as a STORED GENERATED column so search_items() works as
+-- designed. Postgres requires the generation expression to be IMMUTABLE; the multi-arg
+-- to_tsvector/array_to_string composition trips the planner's immutability check, so we
+-- wrap it in an explicitly IMMUTABLE helper (the expression genuinely is immutable —
+-- to_tsvector with a constant regconfig is immutable). Trigger-free and auto-maintained.
+
+CREATE OR REPLACE FUNCTION public.items_search_document(
+	name text,
+	description text,
+	tags text[],
+	categories text[]
+) RETURNS tsvector
+	LANGUAGE sql
+	IMMUTABLE
+	PARALLEL SAFE
+AS $$
+	SELECT to_tsvector(
+		'english'::regconfig,
+		coalesce(name, '') || ' ' ||
+		coalesce(description, '') || ' ' ||
+		coalesce(array_to_string(tags, ' '), '') || ' ' ||
+		coalesce(array_to_string(categories, ' '), '')
+	);
+$$;
+
+ALTER TABLE public.items
+	ADD COLUMN IF NOT EXISTS search_vector tsvector
+	GENERATED ALWAYS AS (public.items_search_document(name, description, tags, categories)) STORED;
+
+CREATE INDEX IF NOT EXISTS items_search_vector_gin_idx ON public.items USING gin (search_vector);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -253,6 +253,10 @@ model Item {
   isValueVisible       Boolean   @default(false) @map("is_value_visible")
   // Vector embeddings stored via raw SQL (pgvector)
   embedding    Unsupported("vector(1024)")?
+  // Full-text search vector — a DB-managed GENERATED column (see migration
+  // 20260716120000_readd_items_search_vector). Declared here only so `db push`
+  // never drops it; the generation expression + GIN index live in the DB.
+  search_vector Unsupported("tsvector")?
   createdAt    DateTime @default(now()) @map("created_at")
   updatedAt    DateTime @updatedAt @map("updated_at")
 


### PR DESCRIPTION
## Problem
`search_items()` (called by \`app/api/items/search/route.ts\`) references \`i.search_vector\`, but that column was dropped in migration \`20260412000000_drop_stale_search_vector_trigger\`. A later migration \`20260609120000_fix_search_items_text_match\` reintroduced \`i.search_vector\` references for hybrid ranking — against a column that no longer existed.

**Effect:** every vector/semantic search call errored (\`column i.search_vector does not exist\`) and the route silently fell back to plain text search. The pgvector semantic search was effectively dead on dev and prod.

## Fix
Recreate \`search_vector\` as a **STORED GENERATED** \`tsvector\` column (name + description + tags + categories), via an \`IMMUTABLE\` helper function (the composed expression otherwise trips Postgres's generated-column immutability check), plus its GIN index. Declared in \`schema.prisma\` as an \`Unsupported("tsvector")\` column so \`db push\` won't drop it.

## Verification
- Applied + verified on the dev database: \`search_items(...)\` now runs with no error; \`search_vector\` column present.
- \`tsc\` clean · 285/285 unit tests · production build compiles.

## DB note
Additive/idempotent migration. Dev DB already updated. The new prod project's DB needs this applied before it serves (pending explicit approval — not applied yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)