### PR TITLE
hotfix: stale service worker bricking clients after deploy, and VAPID variable name

### DIFF
--- a/components/pwa/pwa-provider.tsx
+++ b/components/pwa/pwa-provider.tsx
@@ -114,6 +114,48 @@ export function PWAProvider() {
 			}
 		};
 
+		/**
+		 * Last-resort recovery from a service worker serving a dead build.
+		 *
+		 * A `ChunkLoadError` after a deploy means the HTML we are running references JavaScript
+		 * that no longer exists on the server — almost always a stale worker's cache. The user
+		 * cannot fix that themselves: reloading just re-serves the same cached HTML, so the app is
+		 * bricked until they clear site data, which nobody knows to do. `skipWaiting` should stop
+		 * this happening, but a worker installed *before* that shipped is still out there, so the
+		 * page has to be able to rescue itself.
+		 *
+		 * Guarded by sessionStorage: exactly one recovery attempt per tab, so a genuinely missing
+		 * chunk cannot turn into a reload loop.
+		 */
+		const RECOVERY_FLAG = 'sc-chunk-recovery-attempted';
+		const recoverFromStaleWorker = async (reason: string) => {
+			if (sessionStorage.getItem(RECOVERY_FLAG)) return;
+			sessionStorage.setItem(RECOVERY_FLAG, '1');
+			console.error(`Stale build detected (${reason}); clearing caches and reloading once.`);
+			try {
+				const registrations = await navigator.serviceWorker.getRegistrations();
+				await Promise.all(registrations.map(r => r.unregister()));
+				if ('caches' in window) {
+					const keys = await caches.keys();
+					await Promise.all(keys.map(k => caches.delete(k)));
+				}
+			} catch (error) {
+				console.error('Failed to clear stale caches:', error);
+			}
+			window.location.reload();
+		};
+
+		const handleChunkError = (event: ErrorEvent | PromiseRejectionEvent) => {
+			const message =
+				'reason' in event ? String((event as PromiseRejectionEvent).reason) : (event as ErrorEvent).message;
+			if (/ChunkLoadError|Loading chunk \S+ failed|Importing a module script failed/i.test(message)) {
+				void recoverFromStaleWorker(message.slice(0, 80));
+			}
+		};
+
+		window.addEventListener('error', handleChunkError);
+		window.addEventListener('unhandledrejection', handleChunkError);
+
 		const registerServiceWorker = async () => {
 			const registration = await navigator.serviceWorker.register('/sw.js', { scope: '/' });
 
@@ -147,6 +189,8 @@ export function PWAProvider() {
 		return () => {
 			navigator.serviceWorker.removeEventListener('controllerchange', handleControllerChange);
 			navigator.serviceWorker.removeEventListener('message', handleServiceWorkerMessage);
+			window.removeEventListener('error', handleChunkError);
+			window.removeEventListener('unhandledrejection', handleChunkError);
 		};
 	}, []);
 

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -33,7 +33,21 @@ const requiredSchema = z.object({
  * Absent in development, but their absence in production silently disables a user-visible
  * feature rather than breaking a request, which is exactly the kind of thing that goes unnoticed.
  */
-const PRODUCTION_RECOMMENDED = ['DIRECT_URL', 'RESEND_API_KEY', 'VAPID_PUBLIC_KEY', 'VAPID_PRIVATE_KEY'] as const;
+/**
+ * `NEXT_PUBLIC_VAPID_PUBLIC_KEY` is the name `lib/push.ts` actually reads. An earlier version of
+ * this list said `VAPID_PUBLIC_KEY`, which sent an operator looking for a variable nothing uses.
+ *
+ * It is also `NEXT_PUBLIC_`, so Next inlines it at **build** time: setting it on the host and
+ * restarting is not enough, the app has to be rebuilt or the browser still ships without a key
+ * and the push toggle stays disabled.
+ */
+const PRODUCTION_RECOMMENDED = [
+	'DIRECT_URL',
+	'RESEND_API_KEY',
+	'NEXT_PUBLIC_VAPID_PUBLIC_KEY',
+	'VAPID_PRIVATE_KEY',
+	'VAPID_SUBJECT',
+] as const;
 
 export type EnvCheck = {
 	ok: boolean;

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,11 +6,28 @@ const withPWA = withPWAInit({
 	disable: process.env.NODE_ENV === 'development',
 	register: false,
 	cacheOnFrontEndNav: true,
-	reloadOnOnline: true,
+	// Was `true`, and it reloads the page on every `online` event. On a phone that flaps between
+	// wifi and mobile data that turns into repeated reloads, which reads as the app freezing or
+	// getting stuck. Update handling is explicit in pwa-provider instead.
+	reloadOnOnline: false,
 	fallbacks: {
 		document: '/~offline',
 	},
 	workboxOptions: {
+		// THE CAUSE OF THE POST-DEPLOY ChunkLoadError.
+		//
+		// Without these, a new service worker installs and then *waits* until every tab using the
+		// old one closes. An installed PWA effectively never closes, so users kept running the
+		// previous worker, which served HTML from its own precache — HTML referencing chunk hashes
+		// from a build whose files the deploy had already replaced. The chunk 404s, React never
+		// hydrates, and the page sits on a spinner or throws `ChunkLoadError`.
+		//
+		// `skipWaiting` activates the new worker immediately, `clientsClaim` puts existing tabs
+		// under it, and `cleanupOutdatedCaches` deletes the stale precache rather than leaving it
+		// to serve dead URLs.
+		skipWaiting: true,
+		clientsClaim: true,
+		cleanupOutdatedCaches: true,
 		importScripts: ['/sw-extra.js'],
 		runtimeCaching: [
 			{
@@ -49,7 +66,10 @@ const withPWA = withPWAInit({
 				handler: 'NetworkFirst',
 				options: {
 					cacheName: 'sharecircle-page-cache',
-					networkTimeoutSeconds: 15,
+					// 15s meant a slow phone stared at a blank page for fifteen seconds before the
+					// cache was consulted at all. Five is long enough to prefer the network and
+					// short enough that a bad connection still renders something.
+					networkTimeoutSeconds: 5,
 					expiration: {
 						maxEntries: 40,
 						maxAgeSeconds: 60 * 60,

--- a/tests/unit/lib/env.test.ts
+++ b/tests/unit/lib/env.test.ts
@@ -11,8 +11,11 @@ const COMPLETE = {
 	SUPABASE_JWT_SECRET: 'jwt',
 	DIRECT_URL: 'postgresql://user:pass@host:5432/db',
 	RESEND_API_KEY: 'resend',
-	VAPID_PUBLIC_KEY: 'pub',
+	// The name lib/push.ts actually reads. This fixture previously said VAPID_PUBLIC_KEY, which
+	// is a variable nothing in the app consumes — the same slip the health check was making.
+	NEXT_PUBLIC_VAPID_PUBLIC_KEY: 'pub',
 	VAPID_PRIVATE_KEY: 'priv',
+	VAPID_SUBJECT: 'mailto:ops@example.com',
 } as unknown as NodeJS.ProcessEnv;
 
 /**


### PR DESCRIPTION
Production hotfix for four symptoms reported after the release.

**ChunkLoadError / /login stuck / app freezing — one cause.** The service worker had no `skipWaiting`/`clientsClaim`, so a new worker installed and waited for every tab to close. An installed PWA never closes, so users kept the previous worker, which served HTML from its own precache referencing chunk hashes the deploy had already replaced. The chunk 404s, React never hydrates, page hangs or throws `ChunkLoadError`. Adds `skipWaiting`, `clientsClaim`, `cleanupOutdatedCaches`, plus a one-shot self-recovery in pwa-provider that unregisters workers and clears caches on a chunk error.

Also: `reloadOnOnline` off (it reloaded on every `online` event — reads as freezing on a phone flapping between wifi and data), and document `networkTimeoutSeconds` 15s -> 5s.

**Push disabled on phones.** `/api/health` on prod reports `NEXT_PUBLIC_VAPID_PUBLIC_KEY` unset. The health check was naming `VAPID_PUBLIC_KEY`, which nothing reads — fixed, along with `VAPID_SUBJECT`. Note it is `NEXT_PUBLIC_`, so it is inlined at build time: setting it on the host requires a rebuild.

Verified on prod: health 200, database ok, env ok, migrations applied. 500 unit tests pass, type-check and lint clean.