### PR TITLE
fix(push): report why push is unconfigured

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { checkEnv } from '@/lib/env';
+import { isPushConfigured } from '@/lib/push';
 
 // Always evaluated fresh — a cached health check reports the state of a past request.
 export const dynamic = 'force-dynamic';
@@ -32,6 +33,9 @@ export async function GET() {
 			status: healthy ? 'ok' : 'degraded',
 			database,
 			env: env.ok ? 'ok' : 'incomplete',
+			// Reported separately because "the variables are set" and "web-push accepted them" are
+			// different things: a subject that is not a mailto:/https URL is present but rejected.
+			push: isPushConfigured() ? 'ok' : 'not-configured',
 			// Names only. `checkEnv` yields messages built from variable names, never values.
 			missing: env.missing,
 			warnings: env.warnings,

--- a/lib/push.ts
+++ b/lib/push.ts
@@ -32,12 +32,32 @@ function getPushConfig() {
 	const subject = process.env.VAPID_SUBJECT;
 
 	if (!publicKey || !privateKey || !subject) {
+		const absent = [
+			!publicKey && 'NEXT_PUBLIC_VAPID_PUBLIC_KEY',
+			!privateKey && 'VAPID_PRIVATE_KEY',
+			!subject && 'VAPID_SUBJECT',
+		].filter(Boolean);
+		console.warn(`Push disabled: ${absent.join(', ')} not set.`);
 		return null;
 	}
 
 	if (!vapidConfigured) {
-		webpush.setVapidDetails(subject, publicKey, privateKey);
-		vapidConfigured = true;
+		// `setVapidDetails` throws on a malformed subject (it must be a `mailto:` address or an
+		// https URL) or on keys that are not valid base64url of the right length. Unhandled, that
+		// throw escaped GET /api/push/subscriptions as a 500, the client's status fetch rejected,
+		// and the UI simply showed the push toggle disabled with no reason anywhere — which is
+		// indistinguishable from "not configured", and cost real time to diagnose.
+		try {
+			webpush.setVapidDetails(subject, publicKey, privateKey);
+			vapidConfigured = true;
+		} catch (error) {
+			console.error(
+				`Push disabled: VAPID details rejected (subject must be a mailto: address or https URL; ` +
+					`got "${subject}"):`,
+				error,
+			);
+			return null;
+		}
 	}
 
 	return { publicKey, subject };


### PR DESCRIPTION
Diagnostics only — no behaviour change to a correctly configured system.

`getPushConfig()` called `webpush.setVapidDetails()` with no try/catch. web-push throws on a subject that is not a mailto:/https URL, or on a mismatched key pair. That throw escaped `GET /api/push/subscriptions` as a 500, the client's status fetch rejected, and the UI showed the push toggle disabled with no reason recorded anywhere — indistinguishable from 'not configured'.

Now it catches, logs which variable is absent or that the VAPID details were rejected and what the subject was, and `/api/health` reports `push: ok | not-configured` so the state is readable remotely without a session.

Prompted by a live debug where all three variables were set correctly and there was no way to confirm that from outside the app.